### PR TITLE
Allow for dumping raw Xml as query plan.

### DIFF
--- a/src/QueryPlanVisualizer/QueryPlanVisualizer.cs
+++ b/src/QueryPlanVisualizer/QueryPlanVisualizer.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Windows.Forms;
+using System.Xml;
 using ExecutionPlanVisualizer.Helpers;
 using ExecutionPlanVisualizer.Properties;
 using LINQPad;
@@ -23,7 +24,7 @@ namespace ExecutionPlanVisualizer
             return queryable;
         }
 
-        public static void DumpPlanXml(string planXml)
+        public static void DumpPlanXml(XmlDocument planXml)
         {
             try
             {
@@ -36,7 +37,7 @@ namespace ExecutionPlanVisualizer
 
                 PanelManager.DisplayControl(control, ExecutionPlanPanelTitle);
 
-                ProcessQueryPlan(planXml, control);
+                ProcessQueryPlan(planXml.OuterXml, control);
             }
             catch (Exception exception)
             {

--- a/src/QueryPlanVisualizer/QueryPlanVisualizer.cs
+++ b/src/QueryPlanVisualizer/QueryPlanVisualizer.cs
@@ -5,7 +5,6 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Windows.Forms;
-using System.Xml;
 using ExecutionPlanVisualizer.Helpers;
 using ExecutionPlanVisualizer.Properties;
 using LINQPad;
@@ -24,7 +23,7 @@ namespace ExecutionPlanVisualizer
             return queryable;
         }
 
-        public static void DumpPlanXml(XmlDocument planXml)
+        public static void DumpPlanXml(string planXml)
         {
             try
             {
@@ -37,7 +36,7 @@ namespace ExecutionPlanVisualizer
 
                 PanelManager.DisplayControl(control, ExecutionPlanPanelTitle);
 
-                ProcessQueryPlan(planXml.OuterXml, control);
+                ProcessQueryPlan(planXml, control);
             }
             catch (Exception exception)
             {


### PR DESCRIPTION
I extracted processing of the Query Plan out from DumpPlanInternal and into a new method ProcessQueryPlan.

Then, I added a new public DumpPlanXml that allows to dump a plan from raw Xml.

I was auditing a database with sys.dm_exec_query_stats and knew I could get the query plan XML through sys.dm_exec_query_plan, but copy and pasting the XML into a new file and loading it into SQL Management Studio got old, fast. I found this plugin and with this modification I can show plans for historical queries directly in linqpad.