### PR TITLE
Should not use the same file for each plan and WebView should not write to the LinqPad folder.

### DIFF
--- a/src/QueryPlanVisualizer.LinqPad6/PlanConvertor.cs
+++ b/src/QueryPlanVisualizer.LinqPad6/PlanConvertor.cs
@@ -18,7 +18,9 @@ namespace ExecutionPlanVisualizer
         protected string PlanFileFolderFullPath => Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
                                                 "LINQPadQueryVisualizer", PlanFolder);
 
-        protected string PlanFilePath => Path.Combine(PlanFileFolderFullPath, "plan.html");
+        private string planFileName = $"plan {Guid.NewGuid()}.html";
+
+        protected string PlanFilePath => Path.Combine(PlanFileFolderFullPath, planFileName);
 
         public void Initialize(string query)
         {

--- a/src/QueryPlanVisualizer.LinqPad6/QueryPlanUserControl.Designer.cs
+++ b/src/QueryPlanVisualizer.LinqPad6/QueryPlanUserControl.Designer.cs
@@ -7,18 +7,7 @@
         /// </summary>
         private System.ComponentModel.IContainer components = null;
 
-        /// <summary> 
-        /// Clean up any resources being used.
-        /// </summary>
-        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
-        protected override void Dispose(bool disposing)
-        {
-            if (disposing && (components != null))
-            {
-                components.Dispose();
-            }
-            base.Dispose(disposing);
-        }
+
 
         #region Component Designer generated code
 

--- a/src/QueryPlanVisualizer.LinqPad6/QueryPlanUserControl.Designer.cs
+++ b/src/QueryPlanVisualizer.LinqPad6/QueryPlanUserControl.Designer.cs
@@ -67,7 +67,7 @@
             // 
             // savePlanButton
             // 
-            this.savePlanButton.Location = new System.Drawing.Point(400, 14);
+            this.savePlanButton.Location = new System.Drawing.Point(258, 14);
             this.savePlanButton.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.savePlanButton.Name = "savePlanButton";
             this.savePlanButton.Size = new System.Drawing.Size(94, 30);
@@ -79,7 +79,7 @@
             // planSavedLabel
             // 
             this.planSavedLabel.AutoSize = true;
-            this.planSavedLabel.Location = new System.Drawing.Point(506, 19);
+            this.planSavedLabel.Location = new System.Drawing.Point(351, 19);
             this.planSavedLabel.Name = "planSavedLabel";
             this.planSavedLabel.Size = new System.Drawing.Size(100, 20);
             this.planSavedLabel.TabIndex = 2;
@@ -89,11 +89,11 @@
             // planLocationLinkLabel
             // 
             this.planLocationLinkLabel.ActiveLinkColor = System.Drawing.Color.FromArgb(((int)(((byte)(255)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
-            this.planLocationLinkLabel.AutoSize = true;
+            this.planLocationLinkLabel.AutoSize = false;
             this.planLocationLinkLabel.LinkColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(102)))), ((int)(((byte)(204)))));
-            this.planLocationLinkLabel.Location = new System.Drawing.Point(506, 43);
+            this.planLocationLinkLabel.Location = new System.Drawing.Point(351, 43);
             this.planLocationLinkLabel.Name = "planLocationLinkLabel";
-            this.planLocationLinkLabel.Size = new System.Drawing.Size(165, 20);
+            this.planLocationLinkLabel.Size = new System.Drawing.Size(364, 40);
             this.planLocationLinkLabel.TabIndex = 3;
             this.planLocationLinkLabel.TabStop = true;
             this.planLocationLinkLabel.Text = "plan location goes here";
@@ -393,7 +393,6 @@
             ((System.ComponentModel.ISupportInitialize)(this.missingIndexDetailsBindingSource)).EndInit();
             this.ResumeLayout(false);
             this.PerformLayout();
-
         }
 
         #endregion

--- a/src/QueryPlanVisualizer.LinqPad6/QueryPlanUserControl.Designer.cs
+++ b/src/QueryPlanVisualizer.LinqPad6/QueryPlanUserControl.Designer.cs
@@ -7,7 +7,18 @@
         /// </summary>
         private System.ComponentModel.IContainer components = null;
 
-
+        /// <summary> 
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
 
         #region Component Designer generated code
 

--- a/src/QueryPlanVisualizer.LinqPad6/QueryPlanUserControl.cs
+++ b/src/QueryPlanVisualizer.LinqPad6/QueryPlanUserControl.cs
@@ -64,8 +64,10 @@ namespace ExecutionPlanVisualizer
 
             indexes = DatabaseProvider.GetMissingIndexes(rawPlan);
             var planHtmlPath = PlanProcessor.GeneratePlanHtml(rawPlan);
-            
-            var env = await CoreWebView2Environment.CreateAsync(WebViewFolder);
+
+            var userDataFolder = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "LINQPadQueryVisualizer", "WebView2");
+
+            var env = await CoreWebView2Environment.CreateAsync(WebViewFolder, userDataFolder);
             await webBrowser.EnsureCoreWebView2Async(env);
 
             webBrowser.CoreWebView2.SetVirtualHostNameToFolderMapping("query.plan", Path.GetDirectoryName(planHtmlPath), CoreWebView2HostResourceAccessKind.Allow);

--- a/src/QueryPlanVisualizer.LinqPad6/QueryPlanUserControl.cs
+++ b/src/QueryPlanVisualizer.LinqPad6/QueryPlanUserControl.cs
@@ -19,21 +19,8 @@ namespace ExecutionPlanVisualizer
         public QueryPlanUserControl()
         {
             InitializeComponent();
-        }
 
-        /// <summary> 
-        /// Clean up any resources being used.
-        /// </summary>
-        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
-        protected override void Dispose(bool disposing)
-        {
-            temporaryFiles.Dispose();
-
-            if (disposing && (components != null))
-            {
-                components.Dispose();
-            }
-            base.Dispose(disposing);
+            this.Disposed += (sender, args) => temporaryFiles.Dispose();
         }
 
         private void QueryPlanUserControlLoad(object sender, EventArgs e)

--- a/src/QueryPlanVisualizer.LinqPad6/TemporaryFiles.cs
+++ b/src/QueryPlanVisualizer.LinqPad6/TemporaryFiles.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace ExecutionPlanVisualizer
+{
+
+    public class TemporaryFiles : IDisposable
+    {
+        private List<string> filesToDelete;
+        private List<string> foldersToDelete;
+
+
+        public TemporaryFiles()
+        {
+            filesToDelete = new List<string>();
+            foldersToDelete = new List<string>();
+        }
+
+        public void Dispose()
+        {
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            DeleteFiles();
+        }
+
+        ~TemporaryFiles()
+        {
+            Dispose(disposing: false);
+        }
+
+        public void AddFile(string fileName)
+        {
+            if (String.IsNullOrWhiteSpace(fileName))
+                throw new ArgumentNullException(nameof(fileName));
+
+            filesToDelete.Add(fileName);
+        }
+
+
+        public void AddFolder(string folderName)
+        {
+            if (String.IsNullOrWhiteSpace(folderName))
+                throw new ArgumentNullException(nameof(folderName));
+
+            foldersToDelete.Add(folderName);
+        }
+
+        public string GetTemporaryFileName()
+        {
+            var tempFile = Path.GetTempFileName();
+            AddFile(tempFile);
+            return tempFile;
+        }
+
+        public string CreateTemporaryFolder(string folderName = null)
+        {
+            if (String.IsNullOrWhiteSpace(folderName))
+                folderName = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+
+            Directory.CreateDirectory(folderName);
+            foldersToDelete.Add(folderName);
+
+            return folderName;
+        }
+
+
+        private void Try(Action action)
+        {
+            try { action(); } catch { }
+        }
+
+
+        public void DeleteFiles()
+        {
+            filesToDelete.ForEach(fileName => Try(() => File.Delete(fileName)));
+            filesToDelete.Clear();
+
+            foldersToDelete.ForEach(folder => Try(() => Directory.Delete(folder)));
+            foldersToDelete.Clear();
+        }
+
+    }
+}


### PR DESCRIPTION
I have discovered and hopefully fixed a few issues.

DumpPlan always used the same html file name,  consequently dumping two or more plans from LinqPad meant it always displayed information for the last plan. The PR changes to use a unique name for each plan. It also attempts to delete these temporary files when finished. 

WebBrowser did not specify a user data folder and hence attempts to create files in a subfolder of the LinqPad folder which may not be writeable (or may require admin rights to write to).

Lastly a tweak to avoid the plan location link extending over the Share Plan button.
